### PR TITLE
Add permissions to pull the S3 for the lambda code.

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -80,6 +80,20 @@ data "aws_iam_policy_document" "main_scan" {
   }
 
   statement {
+    sid = "s3GetLambdaCode"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.lambda_s3_bucket}/${var.lambda_package_key}",
+    ]
+  }
+
+  statement {
     sid = "kmsDecrypt"
 
     effect = "Allow"

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -65,6 +65,20 @@ data "aws_iam_policy_document" "main_update" {
       "arn:${data.aws_partition.current.partition}:s3:::${var.av_definition_s3_bucket}/*",
     ]
   }
+
+  statement {
+    sid = "s3GetLambdaCode"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.lambda_s3_bucket}/${var.lambda_package_key}",
+    ]
+  }
 }
 
 resource "aws_iam_role" "main_update" {


### PR DESCRIPTION
Previously it was assumed that the code would be stored within the main bucket. Now we are pulling from another bucket outside the account we need to add explicit permissions for that.